### PR TITLE
feat(docs): setup site for project

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,34 +3,34 @@ name: site
 
 on:
   push:
-    branches: [ main ]
-    paths: [ 'docs/**', "mkdocs.yml", "flake.*"]
+    branches: [main]
+    paths: ["docs/**", "mkdocs.yml", "flake.*"]
   pull_request:
-    branches: [ main ]
-    paths: [ 'docs/**', "mkdocs.yml", "flake.*"]
+    branches: [main]
+    paths: ["docs/**", "mkdocs.yml", "flake.*"]
 
 jobs:
   site:
     name: Build Site
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.1
 
-    - name: "Install Nix ❄️"
-      uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+      - name: "Install Nix ❄️"
+        uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
 
-    - name: "Build 🛠️"
-      run: "nix build .#site"
+      - name: "Build 🛠️"
+        run: "nix build .#site"
 
-    - name: "Deploy 🚀"
-      if: ${{ github.ref == 'refs/heads/main' }}
-      uses: crazy-max/ghaction-github-pages@v3.2.0
-      with:
-        target_branch: gh-pages
-        build_dir: result
-        follow_symlinks: true
-        keep_history: false
-        fqdn: jesusmtnez.es
-        jekyll: false
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Deploy 🚀"
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: crazy-max/ghaction-github-pages@v3.2.0
+        with:
+          target_branch: gh-pages
+          build_dir: result
+          follow_symlinks: true
+          keep_history: false
+          fqdn: jesusmtnez.es
+          jekyll: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,36 @@
+---
+name: site
+
+on:
+  push:
+    branches: [ main ]
+    paths: [ 'docs/**', "mkdocs.yml", "flake.*"]
+  pull_request:
+    branches: [ main ]
+    paths: [ 'docs/**', "mkdocs.yml", "flake.*"]
+
+jobs:
+  site:
+    name: Build Site
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4.1.1
+
+    - name: "Install Nix ❄️"
+      uses: cachix/install-nix-action@6a9a9e84a173d90b3ffb42c5ddaf9ea033fad011 # v23
+
+    - name: "Build 🛠️"
+      run: "nix build .#site"
+
+    - name: "Deploy 🚀"
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: crazy-max/ghaction-github-pages@v3.2.0
+      with:
+        target_branch: gh-pages
+        build_dir: result
+        follow_symlinks: true
+        keep_history: false
+        fqdn: jesusmtnez.es
+        jekyll: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-flakes.yml
+++ b/.github/workflows/update-flakes.yml
@@ -4,7 +4,7 @@ name: update-flake
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 4 * * 1' # runs weekly on Monday at 04:00 UTC
+    - cron: "0 4 * * 1" # runs weekly on Monday at 04:00 UTC
 
 jobs:
   lockfile:

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ kubeconfig
 
 # project
 **/env.secrets
+
+# mkdocs
+site/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 JesusMtnez
+Copyright (c) 2021-2023 JesusMtnez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="https://camo.githubusercontent.com/5b298bf6b0596795602bd771c5bddbb963e83e0f/68747470733a2f2f692e696d6775722e636f6d2f7031527a586a512e706e67" align="center" width="144px" height="144px"/>
 
-# Homelab
+# [Homelab][homelab]
 
 _my home infrastructure and Kubernetes cluster_
 
@@ -18,50 +18,6 @@ _my home infrastructure and Kubernetes cluster_
   [NIX-link]: https://builtwithnix.org
   [K3S-badge]: https://img.shields.io/badge/k3s-v1.28-blue?style=flat-square&logo=k3s&logoColor=yellow
   [K3S-link]: https://k3s.io
+  [homelab]: https://jesusmtnez.es/homelab
 
-## 💻 Hardware
-
-| Device           | Count | RAM    | Disks               | OS     | Arch  | Purpose      |
-| ---------------- | ----- | ------ | ------------------- | ------ | ----- | ------------ |
-| Synology DS216j  | 1     | 512 MB | WD Red Nas 4TB (x2) | DSM 7  | armv7 | NFS + NAS    |
-| Raspberry Pi 1B  | 1     | 512 MB | SD 32GB             | DietPi | armv6 | DNS (PiHole) |
-| Raspberry Pi 3   | 5     | 1 GB   | SD 32GB             | DietPi | armv7 | Kubernetes   |
-
-## 📂 Repository structure
-
-The Git repository contains the following directories:
-
-```sh
-📁 ansible     # Ansible playbooks / roles to setup all the infrastructure
-📁 archive     # unused / old applications
-📁 kubernetes  # Kubernetes cluster defined as code
-├─📁 apps      # Apps deployed into the cluster grouped by namespace
-└─📁 bootstrap # not used yet
-```
-
-## Playbooks
-
-### `entware-install` playbook
-
-Install and configure [Entware][entware] for Synology DSM following [this instructions][entware-dsm].
-
-  [entware]: https://github.com/Entware/Entware/
-  [entware-dsm]: https://github.com/Entware/Entware/wiki/Install-on-Synology-NAS
-
-### `k3s-install` playbook
-
-Install or upgrade k3s cluster deployment using k3sup.
-
-### `upgrade` playbook
-
-Upgrade DietPi systems using `apt` and `dietpi` upgrader. Upgrade DSM python installatio in Synology.
-
-## Credits to:
-
-- [k3s](https://k3s.io) by [Rancher](https://rancher.com/)
-- [alexellis/k3sup](https://github.com/alexellis/k3sup)
-- [OmegaSquad82/ansible-k3sup](https://github.com/OmegaSquad82/ansible-k3sup)
-- [k3s-io/k3s-ansible](https://github.com/k3s-io/k3s-ansible)
-- [k8s-at-home/template-cluster-k3s](https://github.com/k8s-at-home/template-cluster-k3s/)
-- [onedr0p/home-ops](https://github.com/onedr0p/home-ops)
-- [onedr0p/flux-cluster-template](https://github.com/onedr0p/flux-cluster-template)
+**Find all the information at**: https://jesusmtnez.es/homelab

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,67 @@
+<div align="center">
+<img src="https://camo.githubusercontent.com/5b298bf6b0596795602bd771c5bddbb963e83e0f/68747470733a2f2f692e696d6775722e636f6d2f7031527a586a512e706e67" align="center" width="144px" height="144px"/>
+</div>
+
+## Homelab {: align='center'}
+_my home infrastructure and Kubernetes cluster_
+{: align='center'}
+
+[![Built with nix][NIX-badge]][NIX-link]
+[![K3S Version][K3S-badge]][K3S-link]
+[![MIT LICENSE][LICENSE-badge]][LICENSE-link]
+{: align='center'}
+
+
+  [LICENSE-badge]: https://img.shields.io/badge/license-MIT-green.svg?style=flat-square
+  [LICENSE-link]: /LICENSE
+  [NIX-badge]: https://img.shields.io/badge/Built_With-Nix-5277C3.svg?logo=nixos&labelColor=73C3D5&style=flat-square
+  [NIX-link]: https://builtwithnix.org
+  [K3S-badge]: https://img.shields.io/badge/k3s-v1.28-blue?style=flat-square&logo=k3s&logoColor=yellow
+  [K3S-link]: https://k3s.io
+
+## 💻 Hardware
+
+| Device           | Count | RAM    | Disks               | OS     | Arch  | Purpose      |
+| ---------------- | ----- | ------ | ------------------- | ------ | ----- | ------------ |
+| Synology DS216j  | 1     | 512 MB | WD Red Nas 4TB (x2) | DSM 7  | armv7 | NFS + NAS    |
+| Raspberry Pi 1B  | 1     | 512 MB | SD 32GB             | DietPi | armv6 | DNS (PiHole) |
+| Raspberry Pi 3   | 5     | 1 GB   | SD 32GB             | DietPi | armv7 | Kubernetes   |
+
+## 📂 Repository structure
+
+The Git repository contains the following directories:
+
+```sh
+📁 ansible     # Ansible playbooks / roles to setup all the infrastructure
+📁 archive     # unused / old applications
+📁 kubernetes  # Kubernetes cluster defined as code
+├─📁 apps      # Apps deployed into the cluster grouped by namespace
+└─📁 bootstrap # not used yet
+```
+
+## Playbooks
+
+### `entware-install` playbook
+
+Install and configure [Entware][entware] for Synology DSM following [this instructions][entware-dsm].
+
+  [entware]: https://github.com/Entware/Entware/
+  [entware-dsm]: https://github.com/Entware/Entware/wiki/Install-on-Synology-NAS
+
+### `k3s-install` playbook
+
+Install or upgrade k3s cluster deployment using k3sup.
+
+### `upgrade` playbook
+
+Upgrade DietPi systems using `apt` and `dietpi` upgrader. Upgrade DSM python installatio in Synology.
+
+## Credits
+
+- [k3s](https://k3s.io) by [Rancher](https://rancher.com/)
+- [alexellis/k3sup](https://github.com/alexellis/k3sup)
+- [OmegaSquad82/ansible-k3sup](https://github.com/OmegaSquad82/ansible-k3sup)
+- [k3s-io/k3s-ansible](https://github.com/k3s-io/k3s-ansible)
+- [k8s-at-home/template-cluster-k3s](https://github.com/k8s-at-home/template-cluster-k3s/)
+- [onedr0p/home-ops](https://github.com/onedr0p/home-ops)
+- [onedr0p/flux-cluster-template](https://github.com/onedr0p/flux-cluster-template)

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,12 @@
 
   inputs = {
     nixpkgs.url = github:NixOS/nixpkgs/release-23.05;
+
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
+
   };
 
   outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
@@ -34,6 +36,24 @@
           export KUBECONFIG=kubeconfig
         '';
       };
+
+      packages.site = pkgs.stdenv.mkDerivation {
+        name = "homelab-site";
+        src = ./.;
+        nativeBuildInputs = [ (pkgs.python311.withPackages (ps: [ ps.mkdocs ps.mkdocs-material ])) ];
+        buildPhase = "mkdocs build --site-dir $out";
+        dontInstal = true;
+      };
+
+      devShells.site = pkgs.mkShell {
+        name = "docs-shell";
+
+        packages = [
+          (pkgs.python311.withPackages (ps: [ ps.mkdocs ps.mkdocs-material ]))
+        ];
+      };
     };
+
+
   };
 }

--- a/kubernetes/apps/networking/traefik/kustomization.yml
+++ b/kubernetes/apps/networking/traefik/kustomization.yml
@@ -6,5 +6,4 @@ resources:
   - cluster-role.yml
   - deployment.yml
   - service.yml
-
 # source: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#configuration-example

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,29 @@
+site_name: Homelab
+site_url: https://jesusmtnez.es/homelab
+repo_url: https://github.com/JesusMtnez/homelab\
+
+site_description: my home infrastructure and Kubernetes cluster
+site_author: https://jesusmtnez.es/homelab
+copyright: Copyright (c) 2021-2023 JesusMtnez
+
+nav:
+  - Overview: index.md
+
+theme:
+  name: material
+
+  palette:
+    - scheme: slate
+      primary: indigo
+      toggle:
+        icon: material/weather-night
+        name: Dark mode
+
+    - scheme: default
+      primary: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Light mode
+
+markdown_extensions:
+  - attr_list


### PR DESCRIPTION
Setup site for project instead of just a README for further notes

- feat(docs): add homelab site setup with mkdocs
- ci(site): add site workflow to build and publish the site
- refactor(docs): simplify README redirecting to project site page
- fix(license): update license copyright years
